### PR TITLE
minor updates for nodeport

### DIFF
--- a/e3/k8s/platform-depl.yaml
+++ b/e3/k8s/platform-depl.yaml
@@ -13,7 +13,7 @@ spec:
         app: platformservice
     spec:
       containers:
-        - name: platformservice
-          ports:
-            - containerPort: 80
-          image: eliassal/platformservice:latest
+      - name: platformservice
+        ports:
+          - containerPort: 80
+        image: eliassal/platformservice:latest        

--- a/e3/k8s/platforms-np-srv.yaml
+++ b/e3/k8s/platforms-np-srv.yaml
@@ -5,10 +5,9 @@ metadata:
 spec:
   type: NodePort
   selector:
-    app: platformnpservice
+    app: platformservice
   ports:
-    - name: platformservice
-      protocol: TCP
+    - protocol: TCP
       port: 80
       targetPort: 80
       nodePort: 30180


### PR DESCRIPTION
See the updated files for the changes I made.  The biggest "real" change was in the NodePort file.  The Selector app needs to refer to the name of the application (deployment) you are trying to route traffic to.  So `platformservice` here needs to match the `platformservice` name within your `platform-depl.yaml` file.